### PR TITLE
Added handling of EDA signals with no driver events

### DIFF
--- a/sparsEDA.py
+++ b/sparsEDA.py
@@ -396,7 +396,7 @@ def sparsEDA(signalIn,sr,epsilon,Kmax,dmin,rho):
     # PP
     ind = np.argwhere(SCRaux > 0).reshape(-1)
     driver = np.zeros(len(SCRaux))
-    if not ind.shape[0]:
+    if ind.shape[0] == 0:
         return driver, SCL, MSE
     scr_temp = SCRaux[ind]
     ind2 = np.argsort(scr_temp)[::-1]

--- a/sparsEDA.py
+++ b/sparsEDA.py
@@ -395,6 +395,9 @@ def sparsEDA(signalIn,sr,epsilon,Kmax,dmin,rho):
 
     # PP
     ind = np.argwhere(SCRaux > 0).reshape(-1)
+    driver = np.zeros(len(SCRaux))
+    if not ind.shape[0]:
+        return driver, SCL, MSE
     scr_temp = SCRaux[ind]
     ind2 = np.argsort(scr_temp)[::-1]
     scr_ord = scr_temp[ind2]
@@ -406,7 +409,6 @@ def sparsEDA(signalIn,sr,epsilon,Kmax,dmin,rho):
             scr_fin.append(scr_ord[i])
             ind_fin.append(ind[ind2[i]])
 
-    driver = np.zeros(len(SCRaux))
     driver[np.array(ind_fin)] = np.array(scr_fin)
 
     scr_max = scr_fin[0]


### PR DESCRIPTION
Current SparsEDA function fails if EDA has no SCR drivers. This adds an early exit with an all-zeros driver array if no SCR drivers are found.